### PR TITLE
Add 'connection error' message

### DIFF
--- a/templates/project/assets/javascripts/dashing_logger.js
+++ b/templates/project/assets/javascripts/dashing_logger.js
@@ -1,0 +1,18 @@
+(function(){
+
+    var clog = console.log.bind(console);
+
+    console.log = function(message){
+
+      if(message == 'Connection error') {
+        document.getElementById("connection_error").style.display = "flex";
+      }
+
+      if(message == 'Connection opened') {
+        document.getElementById("connection_error").style.display = "none";
+      }
+
+      clog(message)
+    }
+
+})();

--- a/templates/project/assets/stylesheets/application.scss
+++ b/templates/project/assets/stylesheets/application.scss
@@ -248,6 +248,18 @@ h3 {
   padding-top: 5px;
 }
 
+#connection_error {
+    color: #EEE;
+    position: fixed;
+    width: 100%;
+    height: 100%;
+    background-color: #222;
+    z-index: 99;
+    display: none;
+    flex-direction: column;
+    justify-content: center;
+    text-align: center;
+}
 
 // ----------------------------------------------------------------------------
 // Clearfix

--- a/templates/project/dashboards/layout.erb
+++ b/templates/project/dashboards/layout.erb
@@ -9,6 +9,7 @@
   <title><%= yield_content(:title) %></title>
 
   <!-- The javascript and css are managed by sprockets. The files can be found in the /assets folder-->
+  <script type="text/javascript" src="/assets/dashing_logger.js"></script>
   <script type="text/javascript" src="/assets/application.js"></script>
   <link rel="stylesheet" href="/assets/application.css">
 
@@ -17,6 +18,10 @@
 
 </head>
   <body>
+    <div id="connection_error">
+      <h1>Connection error</h1>
+      <p>Check that the server is up and reachable</p>
+    </div>
     <div id="container">
       <%= yield %>
     </div>


### PR DESCRIPTION
When the dashing server goes down you won't always notice. Widgets would have to implement logic to detect the haven't received data for too long.

I have implemented a makeshift solution to detect server issues. As soon as the Javascript log says 'Connection error' a modal div is displayed stating there is a connection problem. The users (viewers) then immediately know there is a problem. Otherwise they could be looking a static data for hours, days, centuries ;)

Ofcourse, a more elegant way of doing this is in the application js itself where the server connection a established and maintained, but I wouldn't go is there right now.
